### PR TITLE
feat: added `igArrowButton` api

### DIFF
--- a/src/PasImGui.pas
+++ b/src/PasImGui.pas
@@ -376,6 +376,8 @@ Type
     Class Function Button(_label: AnsiString): Boolean; Overload; //overload for default size (0,0)
     Class Function SmallButton(_label: PAnsiChar): Boolean;
     {$IfDef INLINE} inline;{$EndIf}
+    Class Function ImGui.ArrowButton(_label: PAnsiChar; _dir: ImGuiDir): Boolean;
+    {$IfDef INLINE} inline;{$EndIf}
     Class Function InvisibleButton(str_id: PAnsiChar; size: ImVec2;
       flags: ImGuiButtonFlags = ImGuiButtonFlags_None): Boolean;
     {$IfDef INLINE} inline;{$EndIf}
@@ -1845,6 +1847,11 @@ End;
 Class Function ImGui.SmallButton(_label: PAnsiChar): Boolean;
 Begin
   Result := igSmallButton(_label);
+End;
+
+Class Function ImGui.ArrowButton(_label: PAnsiChar; _dir: ImGuiDir): Boolean;
+Begin
+  Result := igArrowButton(PAnsiChar(_label), _dir);
 End;
 
 Class Function ImGui.InvisibleButton(str_id: PAnsiChar; size: ImVec2; flags: ImGuiButtonFlags): Boolean;

--- a/src/PasImGui.pas
+++ b/src/PasImGui.pas
@@ -376,7 +376,7 @@ Type
     Class Function Button(_label: AnsiString): Boolean; Overload; //overload for default size (0,0)
     Class Function SmallButton(_label: PAnsiChar): Boolean;
     {$IfDef INLINE} inline;{$EndIf}
-    Class Function ImGui.ArrowButton(_label: PAnsiChar; _dir: ImGuiDir): Boolean;
+    Class Function ArrowButton(_label: PAnsiChar; _dir: ImGuiDir): Boolean;
     {$IfDef INLINE} inline;{$EndIf}
     Class Function InvisibleButton(str_id: PAnsiChar; size: ImVec2;
       flags: ImGuiButtonFlags = ImGuiButtonFlags_None): Boolean;


### PR DESCRIPTION
Hey Coldzer0,

This PR adds igArrowButton api, so it will be included in a future update of imgui-pascal. Even though I can’t compile this version, I still have v1.90.0 available [there](https://github.com/flydev-fr/ImGui-Pascal-v1.90.0), along with a custom-combo example [here](https://github.com/flydev-fr/ImGui-Pascal-v1.90.0/blob/ba1474f0b677e93458c13e34959432eefb68dac0/examples/imCustomCombo.pas)


<img width="458" height="362" alt="custom_combo 1" src="https://github.com/user-attachments/assets/f59279c0-119c-4614-989d-279b93c49f0a" />